### PR TITLE
Change the robot container's code so that it check its alliance  when…

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -102,7 +102,7 @@ public class RobotContainer implements RobotModeChangeListener {
   private FMSTriggers fmsTriggers;
   private ButtonTriggers buttonTriggers;
 
-  private Optional<Alliance> alliance = DriverStation.getAlliance();
+  private Optional<Alliance> alliance;
 
   private double MaxSpeed = ChudbotTunerConstants.kSpeedAt12Volts.in(MetersPerSecond); // kSpeedAt12Volts desired top
                                                                                        // speed
@@ -279,6 +279,7 @@ public class RobotContainer implements RobotModeChangeListener {
     if (swerveSubsystem == null) {
       return;
     }
+    
     fieldTriggers = new FieldTriggers(() -> swerveSubsystem.getState().Pose);
     fmsTriggers = new FMSTriggers(alliance);
     buttonTriggers = new ButtonTriggers(driverJoystick);
@@ -498,6 +499,7 @@ public class RobotContainer implements RobotModeChangeListener {
   }
 
   public void processRobotModeChange(RobotMode currentRobotMode, RobotMode previousRobotMode) {
+    alliance=DriverStation.getAlliance();
     if (currentRobotMode == RobotMode.TELEOP) {
       Joystick realDriverJoystick = driverJoystick.getRealJoystick();
       String driveControllerName = realDriverJoystick.getName();


### PR DESCRIPTION
… processRobotModeChange is called instead of when the robot container is created in case it doesn't have an alliance.