### PR TITLE
Change the robot container's code so that it check its alliance  when…

### DIFF
--- a/src/main/java/frc/robot/Helpers/FMSTriggers.java
+++ b/src/main/java/frc/robot/Helpers/FMSTriggers.java
@@ -12,7 +12,7 @@ public class FMSTriggers {
     public final Trigger isInactivePeriod;
     public final Trigger isEndgame;
 
-    public FMSTriggers(Optional<Alliance> alliance) {
+    public FMSTriggers() {
 
         isActivePeriod = new Trigger(() -> HubTracker.isAllianceHubActive());
         isInactivePeriod = isActivePeriod.negate();

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -281,7 +281,7 @@ public class RobotContainer implements RobotModeChangeListener {
     }
     
     fieldTriggers = new FieldTriggers(() -> swerveSubsystem.getState().Pose);
-    fmsTriggers = new FMSTriggers(alliance);
+    fmsTriggers = new FMSTriggers();
     buttonTriggers = new ButtonTriggers(driverJoystick);
 
     passingState.addTransition(new StateTransition(


### PR DESCRIPTION
… processRobotModeChange is called instead of when the robot container is created in case it doesn't have an alliance.